### PR TITLE
ci: use only python 3.7 with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 
 python:
-  - "3.5"
-  - "3.6"
+  - "3.7"
 
 env:
   global:


### PR DESCRIPTION
Uso de solo de python 3.7 en travisci fix #92 